### PR TITLE
Keep article headers full width in two-column mode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v0.2.1
+
+- **Reader layout**: keep article headers full width when body is in two-column mode.
+
 ## v0.2.0
 
 Highlights

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 var (
 	debugMode bool
 	noColor   bool
-	version   = "0.2.0"
+	version   = "0.2.1"
 	commit    = ""
 	date      = ""
 )

--- a/internal/ui/article.go
+++ b/internal/ui/article.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/muesli/reflow/wordwrap"
 	"github.com/tmustier/economist-tui/internal/article"
 )
 
 func RenderArticleHeader(art *article.Article, styles ArticleStyles, opts ArticleRenderOptions) string {
 	var sb strings.Builder
 	layout := resolveArticleLayout(opts)
-	wrapWidth := layout.WrapWidth
+	wrapWidth := layout.HeaderWrapWidth
 
 	sb.WriteString("\n")
 	wroteOvertitle := writeWrapped(&sb, art.Overtitle, wrapWidth, func(line string) string {
@@ -30,10 +29,7 @@ func RenderArticleHeader(art *article.Article, styles ArticleStyles, opts Articl
 		return styles.Date.Render(line)
 	})
 
-	sb.WriteString("\n")
-	accentStyles := NewStyles(CurrentTheme(), opts.NoColor)
-	sb.WriteString(AccentRule(layout.ContentWidth, accentStyles))
-	sb.WriteString("\n\n")
+	writeHeaderAccent(&sb, layout, opts)
 	return sb.String()
 }
 
@@ -71,19 +67,11 @@ func writeWrapped(sb *strings.Builder, text string, width int, render func(strin
 	if text == "" {
 		return false
 	}
-	for _, line := range wrapHeaderText(text, width) {
+	for _, line := range WrapLines(text, width) {
 		sb.WriteString(render(line))
 		sb.WriteString("\n")
 	}
 	return true
-}
-
-func wrapHeaderText(text string, width int) []string {
-	if width <= 0 {
-		return []string{text}
-	}
-	wrapped := wordwrap.String(text, width)
-	return strings.Split(wrapped, "\n")
 }
 
 func renderOvertitle(text string, styles ArticleStyles) string {

--- a/internal/ui/article_test.go
+++ b/internal/ui/article_test.go
@@ -7,6 +7,32 @@ import (
 	"github.com/tmustier/economist-tui/internal/article"
 )
 
+func TestRenderArticleHeaderUsesFullWidthInColumns(t *testing.T) {
+	title := strings.TrimSpace(strings.Repeat("word ", 14))
+	art := &article.Article{Title: title}
+	opts := ArticleRenderOptions{
+		NoColor:   true,
+		WrapWidth: 80,
+		TwoColumn: true,
+	}
+	layout := resolveArticleLayout(opts)
+	if !layout.UseColumns {
+		t.Fatalf("expected columns to be enabled")
+	}
+
+	header := RenderArticleHeader(art, NewArticleStyles(true), opts)
+	var titleLines []string
+	for _, line := range strings.Split(header, "\n") {
+		if strings.Contains(line, "word") {
+			titleLines = append(titleLines, line)
+		}
+	}
+
+	if len(titleLines) != 1 {
+		t.Fatalf("expected single-line title, got %d lines: %q", len(titleLines), titleLines)
+	}
+}
+
 func TestArticleFooterFormatting(t *testing.T) {
 	styles := NewArticleStyles(false)
 	art := &article.Article{URL: "https://example.com/test"}

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -31,13 +31,14 @@ type ArticleRenderOptions struct {
 }
 
 type ArticleLayout struct {
-	TermWidth    int
-	ContentWidth int
-	Indent       int
-	OuterPadding int
-	WrapWidth    int
-	ColumnWidth  int
-	UseColumns   bool
+	TermWidth       int
+	ContentWidth    int
+	Indent          int
+	OuterPadding    int
+	WrapWidth       int
+	HeaderWrapWidth int
+	ColumnWidth     int
+	UseColumns      bool
 }
 
 func RenderArticle(art *article.Article, opts ArticleRenderOptions) (string, error) {
@@ -125,20 +126,36 @@ func resolveArticleLayout(opts ArticleRenderOptions) ArticleLayout {
 		wrapWidth = columnWidth
 	}
 
+	headerWrapWidth := wrapWidth
+	if useColumns {
+		headerWrapWidth = availableWidth
+	}
+	if headerWrapWidth < 0 {
+		headerWrapWidth = 0
+	}
+
 	outerPadding := 0
 	if opts.Center && termWidth > contentWidth {
 		outerPadding = (termWidth - contentWidth) / 2
 	}
 
 	return ArticleLayout{
-		TermWidth:    termWidth,
-		ContentWidth: contentWidth,
-		Indent:       indent,
-		OuterPadding: outerPadding,
-		WrapWidth:    wrapWidth,
-		ColumnWidth:  columnWidth,
-		UseColumns:   useColumns,
+		TermWidth:       termWidth,
+		ContentWidth:    contentWidth,
+		Indent:          indent,
+		OuterPadding:    outerPadding,
+		WrapWidth:       wrapWidth,
+		HeaderWrapWidth: headerWrapWidth,
+		ColumnWidth:     columnWidth,
+		UseColumns:      useColumns,
 	}
+}
+
+func writeHeaderAccent(sb *strings.Builder, layout ArticleLayout, opts ArticleRenderOptions) {
+	sb.WriteString("\n")
+	accentStyles := NewStyles(CurrentTheme(), opts.NoColor)
+	sb.WriteString(AccentRule(layout.ContentWidth, accentStyles))
+	sb.WriteString("\n\n")
 }
 
 func RenderArticleBodyBase(markdown string, opts ArticleRenderOptions) (string, error) {

--- a/internal/ui/skeleton.go
+++ b/internal/ui/skeleton.go
@@ -62,7 +62,7 @@ type SkeletonHeader struct {
 func RenderSkeletonHeader(h SkeletonHeader, styles SkeletonStyles, opts ArticleRenderOptions) string {
 	var sb strings.Builder
 	layout := resolveArticleLayout(opts)
-	wrapWidth := layout.WrapWidth
+	wrapWidth := layout.HeaderWrapWidth
 
 	sb.WriteString("\n")
 
@@ -75,32 +75,21 @@ func RenderSkeletonHeader(h SkeletonHeader, styles SkeletonStyles, opts ArticleR
 	}
 
 	// Title (real from RSS)
-	if h.Title != "" {
-		for _, line := range WrapLines(h.Title, wrapWidth) {
-			sb.WriteString(styles.Title.Render(line))
-			sb.WriteString("\n")
-		}
-	}
+	writeWrapped(&sb, h.Title, wrapWidth, func(line string) string {
+		return styles.Title.Render(line)
+	})
 
 	// Subtitle (real from RSS)
-	if h.Subtitle != "" {
-		for _, line := range WrapLines(h.Subtitle, wrapWidth) {
-			sb.WriteString(styles.Subtitle.Render(line))
-			sb.WriteString("\n")
-		}
-	}
+	writeWrapped(&sb, h.Subtitle, wrapWidth, func(line string) string {
+		return styles.Subtitle.Render(line)
+	})
 
 	// Date (real from RSS)
-	if h.Date != "" {
-		sb.WriteString(styles.Date.Render(h.Date))
-		sb.WriteString("\n")
-	}
+	writeWrapped(&sb, h.Date, wrapWidth, func(line string) string {
+		return styles.Date.Render(line)
+	})
 
-	// Accent rule
-	sb.WriteString("\n")
-	accentStyles := NewStyles(CurrentTheme(), opts.NoColor)
-	sb.WriteString(AccentRule(layout.ContentWidth, accentStyles))
-	sb.WriteString("\n\n")
+	writeHeaderAccent(&sb, layout, opts)
 
 	return sb.String()
 }
@@ -108,7 +97,7 @@ func RenderSkeletonHeader(h SkeletonHeader, styles SkeletonStyles, opts ArticleR
 // RenderSkeletonBody renders placeholder lines for the article body.
 func RenderSkeletonBody(styles SkeletonStyles, opts ArticleRenderOptions, lineCount int) string {
 	layout := resolveArticleLayout(opts)
-	wrapWidth := layout.WrapWidth
+	wrapWidth := layout.HeaderWrapWidth
 	if wrapWidth <= 0 {
 		wrapWidth = 60
 	}


### PR DESCRIPTION
## Summary
- keep article headers full width when body renders in two columns
- consolidate header wrapping helpers and restore footer formatting test
- update release notes/version

## Testing
- go test ./internal/ui

Fixes #6